### PR TITLE
Change detect name from "Null buildpack" to "Null"

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-echo "Null Buildpack"
+echo "Null"


### PR DESCRIPTION
Since by convention this name does not mention "buildpack".

This makes the buildpack a drop-in replacement for the buildkits hosted version, for an easier transition for Direwolf tests.