### PR TITLE
README: Use buildpack registry name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ hi
 Create an app with the Null Buildpack
 ```bash
 $ git init; git add .; git commit -am 'init'
-$ heroku create --buildpack http://github.com/ryandotsmith/null-buildpack.git
+$ heroku create --buildpack heroku-community/null
 $ git push heroku master
 ```
 


### PR DESCRIPTION
Replaces the out of date buildpack GitHub URL with the buildpack registry alias `heroku-community/null`.